### PR TITLE
Atlantia Update

### DIFF
--- a/common/history/diplomacy/00_subject_relationships.txt
+++ b/common/history/diplomacy/00_subject_relationships.txt
@@ -16,6 +16,12 @@
 			country = c:CUB
 			type = puppet
 		}
+		
+		create_diplomatic_pact = {
+			country = c:ATL
+			type = puppet
+		}
+		
 		create_diplomatic_pact = {
 			country = c:VIJ
 			type = protectorate


### PR DESCRIPTION
Atlantia from DoD-FF added as an existing, playable Spanish puppet with Atlantian culture with laws slightly more liberal than Amazonie 